### PR TITLE
Forced the binary encoding on file read

### DIFF
--- a/lib/whitespace/stripper.rb
+++ b/lib/whitespace/stripper.rb
@@ -2,7 +2,7 @@ module Whitespace
   class Stripper < Base
     class File < Base::File
       def strip
-        lines = ::File.readlines(filename)
+        lines = ::File.readlines(filename, encoding: Encoding::BINARY)
         write_file = false
 
         lines.map do |line|


### PR DESCRIPTION
The `stripper.rb` script has problems with the content of some files
upon reading them to do the whitespace stripping. This commit forces
the stripper to use the BINARY encoding when it reads a file.